### PR TITLE
dbopts.go revamp

### DIFF
--- a/slackParse.go
+++ b/slackParse.go
@@ -56,7 +56,7 @@ Please follow this guide for getting help from the bot:
 
 type _tag: [keyword]_ to see the component, playbooks, appropriate channels, and the anchor associated with this tag
 
-type _anchor: [component]_ to see the anchor and channel in charge of a product component 
+type _anchor: [component]_ to see the anchor and channel in charge of a product component
 
 type _help_ in this channel to see this message again at any time`
 
@@ -84,7 +84,7 @@ type _help tags_ for further information about adding tags
 type _help add_ for help adding other details to the database`
 	case kind == tagsHelp:
 		message = `To add tags to the bot, use the following syntax:
-	
+
 _@[bot] tag [keyword] as [component name]_
 
 Only anchors can add tags. To see a list of valid component names type:
@@ -165,19 +165,19 @@ func handleHelp(ev *slack.MessageEvent, words []string) error {
 // handlesKeywords passed via the "tag" option
 func handleKeywords(ev *slack.MessageEvent, words []string) error {
 	// TODO: handle the printing better
-	var tags []tagInfo
+	var tags []TagInfo
 	var responses []string
 	var s string
 	var r response
 	for i := 1; i < len(words); i++ {
-		tags = keywordAsk(words[i])
+		tags = QueryTag(words[i])
 		fmt.Printf("%v\n", tags)
 		if len(tags) == 0 {
 			s = fmt.Sprintf("There are no components associated with the tag %s - please contact an anchor if you believe this tag should be added", words[i])
 			responses = append(responses, s)
 		} else {
 			for _, tag := range tags {
-				s := fmt.Sprintf("tag: %s, anchor: %s, component: %s, channel: %s, playbook: %s\n", tag.name, usrFormat(tag.anchor), tag.component, chanFormat(tag.slackChannelID), tag.playbook)
+				s = fmt.Sprintf("tag: %s, anchor: %s, component: %s, playbook: %s\n", tag.Name, usrFormat(tag.Anchor), chanFormat(tag.ComponentChan), tag.PlaybookURL)
 				responses = append(responses, s)
 			}
 		}

--- a/supportBot.go
+++ b/supportBot.go
@@ -64,8 +64,8 @@ func init() {
 	if !ok {
 		log.Fatal("Could not find database URI")
 	}
-	dbConnect()
-	err = checkTables()
+	InitDB()
+	err = MigrateDB()
 	if err != nil {
 		log.Error("Could not query tables and had a problem creating them successfully, closing")
 		log.Fatal(err)

--- a/tagCache.go
+++ b/tagCache.go
@@ -24,12 +24,12 @@ package main
 
 // tagCache is just a hashmap of tags to tagInfo. Further methods are defined to ease use of the cache
 type tagCache struct {
-	tags  map[string]tagInfo
+	tags  map[string]TagInfo
 	count int
 }
 
 // Find gets the tagInfo associated with a tag
-func (cache *tagCache) Find(t string) tagInfo {
+func (cache *tagCache) Find(t string) TagInfo {
 	return cache.tags[t]
 
 }
@@ -41,7 +41,7 @@ func (cache *tagCache) Contains(t string) bool {
 }
 
 // Add adds a tag + tagInfo to the cache
-func (cache *tagCache) Add(t string, tag tagInfo) {
+func (cache *tagCache) Add(t string, tag TagInfo) {
 	if cache.count == 0 || !cache.Contains(t) {
 		cache.tags[t] = tag
 	}


### PR DESCRIPTION
This changes the way we handle database operations so that we no longer have SQL embedded in the code and all database queries are handled by GORM. 

The database objects that we have kept in our final database model are component and tag because the anchor logic is not really needed right now and can be expanded if needed at some point in the future.

Some functions and structs have been renamed to start with a capital letter, following golang conventions for external references and for this reason IMO this should be merged asap to avoid future conflicts.